### PR TITLE
[STOR-2159] Alterada versão de lib de certificado

### DIFF
--- a/pom-base.xml
+++ b/pom-base.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>br.com.swconsultoria</groupId>
             <artifactId>java_certificado</artifactId>
-            <version>3.4</version>
+            <version>3.6</version>
         </dependency>
         <!-- Ini4J -->
         <dependency>


### PR DESCRIPTION
### Descrição
A versão da lib de certificado do pom-base.xml ficou desatualizada durante a atualização anterior da versão do repositório. Por consequência, um cliente do MS continua sem conseguir emitir notas fiscais. Este PR corrige a versão para a 3.6.

### PR Relacionadas
Não se aplica.

### Link da tarefa no JIRA
https://asaasdev.atlassian.net/browse/STOR-2159

### Serviços afetados
java_nfe

### Prints do desenvolvimento
Não se aplica.
