### PR TITLE
SKYW-387-Atualizar-biblioteca-Java-NF-e-remove-maven-gpg-plugin

### DIFF
--- a/pom-base.xml
+++ b/pom-base.xml
@@ -42,7 +42,6 @@
         <lombok.version>1.18.38</lombok.version>
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
-        <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
@@ -212,20 +211,6 @@
                     <pushChanges>false</pushChanges>
                     <localCheckout>true</localCheckout>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>${maven-gpg-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Descrição
Esse PR remove a lib `maven-gpg-plugin`, introduzida na ultima atualização, do pom do base `pom-base.xml`

### PR Relacionadas

### Link da tarefa no JIRA
https://asaasdev.atlassian.net/browse/SKYW-387

### Serviços afetados
Java_NFe

### Prints do desenvolvimento
