### PR TITLE
SKYW-2339 - Problema ao rodar code artifacts

### DIFF
--- a/pom-base.xml
+++ b/pom-base.xml
@@ -233,15 +233,9 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>sonatype-nexus</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Descrição

Substitui `nexus-staging-maven-plugin:1.6.13` pelo `maven-deploy-plugin:3.1.2` no `pom-base.xml`.

O plugin `nexus-staging-maven-plugin` é destinado ao staging do Maven Central (Sonatype OSS) e não estava disponível no Nexus interno, causando falha no build do Jenkins com erro "Unresolveable build extension". O `maven-deploy-plugin` é o plugin padrão para deploy em repositórios Nexus internos e já aponta para o `distributionManagement` configurado.

### Link da tarefa no JIRA

https://asaasdev.atlassian.net/browse/SKYW-2339

### Serviços afetados

java-nfe

### Revisado Local pela IA
- [ ] Sim