### PR TITLE
SKYW-2339 - Problema ao rodar code artifacts

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -8,5 +8,6 @@ ARG nexusPass
 
 WORKDIR /app
 COPY . /app
+RUN find /root/.m2/repository -name "*.lastUpdated" -delete 2>/dev/null || true
 RUN mvn deploy -f pom-base.xml -s mavensettings.xml -Duser=$nexusUser -Dpassword=$nexusPass -Dversao=$nameSpace $DskipTests
 


### PR DESCRIPTION
### Descrição

Remove arquivos de cache negativo do Maven (`.lastUpdated`) antes de executar o build no `Dockerfile-build`. Isso evita que entradas de cache corrompidas ou desatualizadas presentes na imagem base `maven-services` impeçam o download de plugins como `maven-source-plugin:3.3.1` do Nexus.

### Link da tarefa no JIRA

https://asaasdev.atlassian.net/browse/SKYW-2339

### Revisado Local pela IA
- [ ] Sim