### PR TITLE
SKYW-2339 - Problema ao rodar code artifacts

### DIFF
--- a/mavensettings.xml
+++ b/mavensettings.xml
@@ -36,12 +36,6 @@
 		to a remote server. | -->
 	<servers>
 		<server>
-			<!-- usuário para download de artefatos -->
-			<id>down.nexus.prod.baseerp.com.br</id>
-            <username>${user}</username>
-            <password>${password}</password>
-		</server>
-		<server>
 			<!-- usuário para upload de artefatos -->
 			<id>up.nexus.prod.baseerp.com.br</id>
             <username>${user}</username>


### PR DESCRIPTION
### Descrição

Remove a entrada `<server>` de download (`down.nexus.prod.baseerp.com.br`) do `mavensettings.xml`. O Maven 3.8+ não faz fallback para acesso anônimo quando recebe 401, diferente do Maven 3.6.x. Como o Nexus permite leitura anônima, enviar credenciais causava falha na resolução de plugins (ex.: `maven-source-plugin:3.3.1`). As credenciais de upload (`up.nexus.prod.baseerp.com.br`) foram mantidas.

### Link da tarefa no JIRA

https://asaasdev.atlassian.net/browse/SKYW-2339

### Revisado Local pela IA
- [ ] Sim