### PR TITLE
SKYW-2339 - Problema ao rodar code artifacts

### DIFF
--- a/pom-base.xml
+++ b/pom-base.xml
@@ -247,35 +247,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>${maven-source-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven-javadoc-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <failOnError>false</failOnError>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>


### PR DESCRIPTION
### Descrição

Remove `maven-source-plugin` e `maven-javadoc-plugin` do `pom-base.xml`. O buildah no K8s não consegue baixar novos artefatos do Nexus, e esses plugins não estão pré-cacheados na imagem `maven-services:1.9`. A remoção não afeta o JAR principal (`java-nfe-4.1.1-local-SNAPSHOT.jar`) consumido pelo `service-nfe-api`.

### Link da tarefa no JIRA

https://asaasdev.atlassian.net/browse/SKYW-2339

### Revisado Local pela IA
- [ ] Sim