### PR TITLE
[SKYW-2345] - Implementação suporte a3 nativo para evento generico de nf e nfe a3

### DIFF
--- a/src/main/java/br/com/swconsultoria/nfe/EventoGenericoA3.java
+++ b/src/main/java/br/com/swconsultoria/nfe/EventoGenericoA3.java
@@ -1,0 +1,37 @@
+package br.com.swconsultoria.nfe;
+
+import javax.xml.bind.JAXBException;
+import br.com.swconsultoria.nfe.dom.ConfiguracoesNfe;
+import br.com.swconsultoria.nfe.dom.enuns.DocumentoEnum;
+import br.com.swconsultoria.nfe.dom.enuns.ServicosEnum;
+import br.com.swconsultoria.nfe.exception.NfeException;
+import br.com.swconsultoria.nfe.schemas_eventos.TEnvEventoGenerico;
+import br.com.swconsultoria.nfe.schemas_eventos.TProcEventoGenerico;
+import br.com.swconsultoria.nfe.schemas_eventos.TRetEnvEventoGenerico;
+import br.com.swconsultoria.nfe.schemas_eventos.TRetEventoGenerico;
+import br.com.swconsultoria.nfe.util.ConstantesUtil;
+import br.com.swconsultoria.nfe.util.XmlNfeUtil;
+
+class EventoGenericoA3 {
+
+    private EventoGenericoA3() {}
+
+    static TRetEnvEventoGenerico eventoGenericoA3(ConfiguracoesNfe config, boolean valida, String xmlAssinado)
+            throws NfeException {
+        String xmlRetorno = EventosA3.enviarEvento(config, xmlAssinado, ServicosEnum.EVENTO_GENERICO, valida, DocumentoEnum.NFE);
+        return XmlNfeUtil.xmlToObject(xmlRetorno, TRetEnvEventoGenerico.class);
+    }
+
+    static String criaProcEventoGenericoA3(ConfiguracoesNfe config, String xmlAssinado, TRetEventoGenerico retorno)
+            throws NfeException {
+        try {
+            TProcEventoGenerico procEvento = new TProcEventoGenerico();
+            procEvento.setVersao(ConstantesUtil.VERSAO.EVENTO_GENERICO);
+            procEvento.setEvento(XmlNfeUtil.xmlToObject(xmlAssinado, TEnvEventoGenerico.class).getEvento().get(0));
+            procEvento.setRetEvento(retorno);
+            return XmlNfeUtil.objectToXml(procEvento, config.getEncode());
+        } catch (JAXBException e) {
+            throw new NfeException(e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/br/com/swconsultoria/nfe/NfeA3.java
+++ b/src/main/java/br/com/swconsultoria/nfe/NfeA3.java
@@ -8,6 +8,8 @@ import br.com.swconsultoria.nfe.dom.enuns.PessoaEnum;
 import br.com.swconsultoria.nfe.exception.NfeException;
 import br.com.swconsultoria.nfe.schemas_eventos.TEnvEventoCancelamento;
 import br.com.swconsultoria.nfe.schemas_eventos.TRetEnvEventoCancelamento;
+import br.com.swconsultoria.nfe.schemas_eventos.TRetEnvEventoGenerico;
+import br.com.swconsultoria.nfe.schemas_eventos.TRetEventoGenerico;
 import br.com.swconsultoria.nfe.schemas.RetDistDFeInt;
 import br.com.swconsultoria.nfe.schemas.TEnviNFe;
 import br.com.swconsultoria.nfe.schemas.TRetEnviNFe;
@@ -79,6 +81,14 @@ public class NfeA3 {
     public static String manifestacaoMontaXmlA3(ConfiguracoesNfe config,
             br.com.swconsultoria.nfe.schemas_eventos.TEnvEventoManifestacao evento) throws NfeException {
         return ManifestacaoDestinatarioA3.montarXML(ConfiguracoesUtil.iniciaConfiguracoes(config), evento);
+    }
+
+    public static TRetEnvEventoGenerico eventoGenericoA3(ConfiguracoesNfe config, boolean valida, String xmlAssinado) throws NfeException {
+        return EventoGenericoA3.eventoGenericoA3(ConfiguracoesUtil.iniciaConfiguracoes(config), valida, xmlAssinado);
+    }
+
+    public static String criaProcEventoGenericoA3(ConfiguracoesNfe config, String xmlAssinado, TRetEventoGenerico retorno) throws NfeException {
+        return EventoGenericoA3.criaProcEventoGenericoA3(ConfiguracoesUtil.iniciaConfiguracoes(config), xmlAssinado, retorno);
     }
 
 }

--- a/src/main/java/br/com/swconsultoria/nfe/NfeA3.java
+++ b/src/main/java/br/com/swconsultoria/nfe/NfeA3.java
@@ -27,11 +27,11 @@ public class NfeA3 {
     public static TEnviNFe montaNfeA3(ConfiguracoesNfe config, String xmlAssinado, boolean valida) throws NfeException {
         return EnviarA3.montaNfeA3(ConfiguracoesUtil.iniciaConfiguracoes(config), xmlAssinado, valida);
     }
-    
+
     public static TRetEnviNFe enviarNfeA3(ConfiguracoesNfe config, TEnviNFe enviNFe, DocumentoEnum tipoDocumento) throws NfeException {
         return Enviar.enviaNfe(ConfiguracoesUtil.iniciaConfiguracoes(config), enviNFe, tipoDocumento);
     }
-    
+
     public static String montaXmleventoCancelamento(ConfiguracoesNfe config, TEnvEventoCancelamento enviEvento) throws NfeException {
         return CancelarA3.montaXmleventoCancelamento(ConfiguracoesUtil.iniciaConfiguracoes(config), enviEvento);
     }
@@ -90,5 +90,4 @@ public class NfeA3 {
     public static String criaProcEventoGenericoA3(ConfiguracoesNfe config, String xmlAssinado, TRetEventoGenerico retorno) throws NfeException {
         return EventoGenericoA3.criaProcEventoGenericoA3(ConfiguracoesUtil.iniciaConfiguracoes(config), xmlAssinado, retorno);
     }
-
 }


### PR DESCRIPTION
### Descrição
Adiciona suporte a certificado A3 para o fluxo de evento genérico de NF-e (como DELIVERY_FORECAST_DATE_UPDATE, EVENT_CANCELLATION), completando o mesmo padrão já existente para emissão, cancelamento, CCe e inutilização.

Novo arquivo EventoGenericoA3 expõe:

- eventoGenericoA3: delega pra EventosA3.enviarEvento (já usado internamente pelos demais fluxos A3) com ServicosEnum.EVENTO_GENERICO.
- criaProcEventoGenericoA3: monta o XML final do procEvento a partir do XML já assinado pelo cliente, sem chamar Assinar.assinaNfe de novo (que falharia no servidor, sem certificado disponível).
Ambos expostos em NfeA3, seguindo o mesmo padrão de delegação de cancelarNfeA3/cceA3/inutilizacaoA3 (via ConfiguracoesUtil.iniciaConfiguracoes).

### PR Relacionadas

### Link da tarefa no JIRA
https://asaasdev.atlassian.net/browse/SKYW-2345

### Serviços afetados

### Prints do desenvolvimento

### Revisado Local pela IA
- [ ] Sim
